### PR TITLE
Download ocean images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build
+*.egg-info
+__pycache__

--- a/landsatlinks/cli.py
+++ b/landsatlinks/cli.py
@@ -75,8 +75,8 @@ def main():
     start, end = [datetime.strftime(datetime.strptime(date, '%Y%m%d'), '%Y-%m-%d') for date in dates]
     # validate and set cloud cover thresholds
     minCC, maxCC = args.cloudcover.split(',')
-    if not all([0 <= cc <= 100 for cc in [float(minCC), float(maxCC)]]):
-        print('Error: Cloud cover values must be between 0 and 100.')
+    if not all([-1 <= cc <= 100 for cc in [float(minCC), float(maxCC)]]):
+        print('Error: Cloud cover values must be between -1 and 100.')
         exit(1)
     # seasonal filter
     seasonalFilter = [int(month) for month in args.months.split(',')]

--- a/landsatlinks/parseargs.py
+++ b/landsatlinks/parseargs.py
@@ -52,8 +52,8 @@ def parse_cli_arguments():
     )
     parser_search.add_argument(
         '-c', '--cloudcover',
-        default='0,100',
-        help='Percent (land) cloud cover range to be considered. \nDefault: 0,100'
+        default='-1,100',
+        help='Percent (land) cloud cover range to be considered. \nDefault: -1,100'
     )
     parser_search.add_argument(
         '-m', '--months',


### PR DESCRIPTION
landsatlinks only allows you to define a cloud cover range between 0 .. 100

The M2M API seems to use the Land Cloud Cover metadata item, which is simply set to -1 if the image does not contain land

This PR changes to lower minimum, and default to -1%. Although this is a silly value, it enables retrieving those images

This PR solves issue https://github.com/ernstste/landsatlinks/issues/7

-----

Secondly, I added the pip build artifact files to a ``.gitignore`` file to not track those changes

Cheers,
David