### PR TITLE
Reading secret files with trailing newline(s)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,46 @@
+name: 🧪 Python Tests
+
+on:
+  push:
+    branches:
+      - '**'
+
+  pull_request:
+    branches:
+      - '**'
+
+  release:
+    types: [ published ]
+
+jobs:
+  # Run python tests
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_version: [ '3.9', '3.10', '3.12' ]
+      fail-fast: true
+
+    env:
+      PYTHON_VERSION: ${{ matrix.python_version}}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python_version}}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install pytest
+
+      - name: Run unittests
+        run: |
+          echo "$(pwd)"
+          export PYTHONPATH="${PYTHONPATH}:$(pwd)"
+          pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/*
 test/*
 build
+tmp/
 *.egg-info
 __pycache__

--- a/landsatlinks/utils.py
+++ b/landsatlinks/utils.py
@@ -77,6 +77,7 @@ def check_date_validity(dates: list, name: str) -> None:
             print(f'Error: {name} dates not provided in format YYYYMMDD,YYYYMMDD or date is invalid.\ndate')
             exit(1)
 
+
 def check_tile_validity(tile_list: list) -> bool:
     regex_pattern = re.compile('^[0-2][0-9]{2}[0-2][0-9]{2}$')
     tiles_valid = True
@@ -113,7 +114,9 @@ def load_secret(file_path: str) -> list:
     full_path = os.path.realpath(file_path)
     validate_file_paths(full_path, 'secrets', file=True, write=False)
     with open(file_path) as file:
-        secret = [line.rstrip() for line in file]
+        secret = file.read().strip().split()
+        # remove whitespaces
+        secret = [s.strip() for s in secret]
     if (
             len(secret) not in [2, 3] or
             len(secret) == 2 and secret[0] == 'app-token' or

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+from pathlib import Path
+
+from landsatlinks.utils import load_secret
+
+
+class TestUtils(unittest.TestCase):
+
+    def create_tmp_dir(self):
+        """
+        Create a temporary directory for the calling test method.
+        """
+        root = Path(__file__).parents[1] / 'tmp'
+        path = root / self.__class__.__name__ / self._testMethodName
+        os.makedirs(path, exist_ok=True)
+        return path
+
+    def test_load_secret(self):
+        result1 = ['app-token', 'user', 'token']
+        result2 = ['user', 'password']
+        valid_examples = [
+            (result1, 'app-token\nuser\ntoken'),
+            (result1, 'app-token\n\tuser\t\ntoken\n\n'),
+            (result1, '\napp-token\nuser\ntoken  '),
+            (result2, 'user\npassword'),
+            (result2, 'user\npassword\n\n'),
+            (result2, '\nuser\npassword\t\n'),
+        ]
+
+        tmp_dir = self.create_tmp_dir()
+
+        for i, (expected, example) in enumerate(valid_examples):
+            path = tmp_dir / f'secret_example_{i}.txt'
+            with open(path, 'w') as f:
+                f.write(example)
+            result = load_secret(path.as_posix())
+            self.assertEqual(result, expected, f'Example {i + 1}:"{example}"\nexpected {expected}, got {result}')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR  fixes #11 (reading of secret files with n > 3 lines) 

The changes to `landsatlinks/utils.py` are covered with a unit test in` tests/test_utils.py`
`.github/workflows/run-tests.yml ` ensure that python unit tests are tested on pushed to gh.